### PR TITLE
Needs GHC >= 7.8 due to GHC.Conc.threadWaitReadSTM

### DIFF
--- a/socket.cabal
+++ b/socket.cabal
@@ -42,7 +42,7 @@ library
                      , System.Socket.Internal.Socket
                      , System.Socket.Internal.Exception
                      , System.Socket.Internal.MsgFlags
-  build-depends:       base < 5
+  build-depends:       base >= 4.7 && < 5
                      , bytestring < 0.11
   hs-source-dirs:      src
   build-tools:         hsc2hs
@@ -58,7 +58,7 @@ test-suite basic
   main-is:             Basic.hs
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
-  build-depends:       base < 5
+  build-depends:       base >= 4.7 && < 5
                      , bytestring < 0.11
                      , socket
                      , async


### PR DESCRIPTION
I've revised existing versions (http://hackage.haskell.org/package/socket/revisions/) so there is no need for a new release.

Before:
![screen shot 2015-05-29 at 10 35 12](https://cloud.githubusercontent.com/assets/100681/7879261/36bd4662-05ef-11e5-9f50-aed3892d118c.png)

After: http://matrix.hackage.haskell.org/package/socket
