### PR TITLE
Exception: Add EOPNOTSUPP.

### DIFF
--- a/platform/linux/include/hs_socket.h
+++ b/platform/linux/include/hs_socket.h
@@ -28,6 +28,7 @@ int hs_get_last_socket_error(void);
 #define SEISCONN               EISCONN
 #define SETIMEDOUT             ETIMEDOUT
 #define SEPIPE                 EPIPE
+#define SEOPNOTSUPP            EOPNOTSUPP
 
 /* MSG_NOSIGNAL might not be available (i.e. on MacOSX and Solaris).
  *   In this case it gets defined as 0. This is relatively

--- a/platform/win32/include/hs_socket.h
+++ b/platform/win32/include/hs_socket.h
@@ -126,3 +126,4 @@ int hs_get_last_socket_error(void);
 #define SEISCONN               WSAEISCONN
 #define SETIMEDOUT             WSAETIMEDOUT
 #define SEPIPE                 WSAECONNABORTED
+#define SEOPNOTSUPP            WSAEOPNOTSUPP

--- a/src/System/Socket/Internal/Exception.hsc
+++ b/src/System/Socket/Internal/Exception.hsc
@@ -30,6 +30,7 @@ instance Show SocketException where
     | e == eIsConnected          = "eIsConnected"
     | e == eTimedOut             = "eTimedOut"
     | e == ePipe                 = "ePipe"
+    | e == eOperationNotSupported  = "eOperationNotSupported"
     | otherwise                  = "SocketException " ++ show i
 
 eOk                       :: SocketException
@@ -76,3 +77,6 @@ eTimedOut                  = SocketException (#const SETIMEDOUT)
 
 ePipe                     :: SocketException
 ePipe                      = SocketException (#const SEPIPE)
+
+eOperationNotSupported    :: SocketException
+eOperationNotSupported     = SocketException (#const SEOPNOTSUPP)


### PR DESCRIPTION
This happens e.g. when you try to `accept` on a socket that's
not a `Stream` socket.

I haven't tested whether it works on Windows, please do that for me :)
