### PR TITLE
Export MessageFlags constructor.

### DIFF
--- a/src/System/Socket.hsc
+++ b/src/System/Socket.hsc
@@ -87,7 +87,7 @@ module System.Socket (
   , HasNameInfo (..)
   -- * Flags
   -- ** MessageFlags
-  , MessageFlags ()
+  , MessageFlags (..)
   , msgEndOfRecord
   , msgNoSignal
   , msgOutOfBand


### PR DESCRIPTION
This is needed for socket-sctp, which passes a MessageFlags to
sctp_sendmsg via FFI.