### PR TITLE
Possibility to get the current address of a socket.

### DIFF
--- a/platform/linux/cbits/hs_socket.c
+++ b/platform/linux/cbits/hs_socket.c
@@ -105,3 +105,9 @@ int hs_setsockopt(int fd, int level, int optname, const void *optval, int  optle
   *err = errno;
   return i;
 }
+
+int hs_getsockname(int fd, struct sockaddr *addr, socklen_t *addrlen, int *err) {
+  int i = getsockname(fd, addr, addrlen);
+  *err = errno;
+  return i;
+}

--- a/platform/linux/src/System/Socket/Internal/Platform.hsc
+++ b/platform/linux/src/System/Socket/Internal/Platform.hsc
@@ -11,7 +11,7 @@ module System.Socket.Internal.Platform
   ( waitRead, waitWrite, waitConnected, c_socket, c_close, c_connect,
     c_accept, c_bind, c_listen, c_recv, c_recvfrom, c_send, c_sendto,
     c_freeaddrinfo, c_getaddrinfo, c_getnameinfo, c_memset, c_gai_strerror,
-    c_setsockopt, c_getsockopt) where
+    c_setsockopt, c_getsockopt, c_getsockname) where
 
 import Control.Monad ( when, unless )
 import Control.Concurrent.MVar
@@ -114,3 +114,6 @@ foreign import ccall safe "getnameinfo"
 
 foreign import ccall unsafe "gai_strerror"
   c_gai_strerror  :: CInt -> IO CString
+
+foreign import ccall unsafe "hs_getsockname"
+  c_getsockname  :: Fd -> Ptr a -> Ptr CInt -> Ptr CInt -> IO CInt

--- a/platform/win32/cbits/hs_socket.c
+++ b/platform/win32/cbits/hs_socket.c
@@ -189,3 +189,11 @@ void hs_freeaddrinfo(struct addrinfo *res) {
   freeaddrinfo(res);
   return;
 };
+
+int hs_getsockname(int fd, struct sockaddr *addr, socklen_t *addrlen, int *err) {
+  int i = getsockname(fd, addr, addrlen);
+  if (i < 0) {
+    *err = WSAGetLastError();
+  }
+  return i;
+}

--- a/platform/win32/src/System/Socket/Internal/Platform.hsc
+++ b/platform/win32/src/System/Socket/Internal/Platform.hsc
@@ -132,3 +132,6 @@ foreign import ccall unsafe "hs_freeaddrinfo"
 
 foreign import ccall safe "hs_getnameinfo"
   c_getnameinfo  :: Ptr a -> CInt -> CString -> CInt -> CString -> CInt -> CInt -> IO CInt
+
+foreign import ccall unsafe "hs_getsockname"
+  c_getsockname  :: Fd -> Ptr a -> Ptr CInt -> Ptr CInt -> IO CInt


### PR DESCRIPTION
This PR proposes `getAddress`, a wrapper around the `getsockname` syscall. It can be useful for e.g. querying a socket's port number after binding it to port `0` (any available port).

**WARNING**: I have not tested the Win32 implementation.