### PR TITLE
Add shutdown operation for Stream sockets

### DIFF
--- a/platform/linux/cbits/hs_socket.c
+++ b/platform/linux/cbits/hs_socket.c
@@ -111,3 +111,9 @@ int hs_getsockname(int fd, struct sockaddr *addr, socklen_t *addrlen, int *err) 
   *err = errno;
   return i;
 }
+
+int hs_shutdown(int fd, int how, int *err) {
+  int i = shutdown(fd, how);
+  *err = errno;
+  return i;
+}

--- a/platform/linux/include/hs_socket.h
+++ b/platform/linux/include/hs_socket.h
@@ -28,6 +28,8 @@ int hs_recvfrom(int fd,       void *buf, size_t len, int flags, struct sockaddr 
 int hs_getsockopt(int fd, int level, int option_name,       void *option_value, int *option_len, int *err);
 int hs_setsockopt(int fd, int level, int option_name, const void *option_value, int  option_len, int *err);
 
+int hs_shutdown(int fd, int how, int *err);
+
 #define SEOK                   0
 #define SEINTR                 EINTR
 #define SEAGAIN                EAGAIN

--- a/platform/linux/src/System/Socket/Internal/Platform.hsc
+++ b/platform/linux/src/System/Socket/Internal/Platform.hsc
@@ -11,7 +11,7 @@ module System.Socket.Internal.Platform
   ( waitRead, waitWrite, waitConnected, c_socket, c_close, c_connect,
     c_accept, c_bind, c_listen, c_recv, c_recvfrom, c_send, c_sendto,
     c_freeaddrinfo, c_getaddrinfo, c_getnameinfo, c_memset, c_gai_strerror,
-    c_setsockopt, c_getsockopt, c_getsockname) where
+    c_setsockopt, c_getsockopt, c_getsockname, c_shutdown) where
 
 import Control.Monad ( when, unless )
 import Control.Concurrent.MVar
@@ -114,3 +114,6 @@ foreign import ccall unsafe "gai_strerror"
 
 foreign import ccall unsafe "hs_getsockname"
   c_getsockname  :: Fd -> Ptr a -> Ptr CInt -> Ptr CInt -> IO CInt
+
+foreign import ccall unsafe "hs_shutdown"
+  c_shutdown     :: Fd -> CInt -> Ptr CInt -> IO CInt

--- a/platform/win32/cbits/hs_socket.c
+++ b/platform/win32/cbits/hs_socket.c
@@ -197,3 +197,11 @@ int hs_getsockname(int fd, struct sockaddr *addr, socklen_t *addrlen, int *err) 
   }
   return i;
 }
+
+int hs_shutdown(int fd, int how, int *err) {
+  int i = shutdown(fd, how);
+  if (i != 0) {
+    *err = WSAGetLastError();
+  }
+  return i;
+}

--- a/platform/win32/include/hs_socket.h
+++ b/platform/win32/include/hs_socket.h
@@ -103,6 +103,8 @@ int  hs_getnameinfo(const struct sockaddr *sa, int salen,
 
 void hs_freeaddrinfo(struct addrinfo *res);
 
+int hs_shutdown(int fd, int how, int *err);
+
 #define SEOK                   0
 #define SEINTR                 WSAEINTR
 #define SEAGAIN                WSATRY_AGAIN

--- a/platform/win32/src/System/Socket/Internal/Platform.hsc
+++ b/platform/win32/src/System/Socket/Internal/Platform.hsc
@@ -135,3 +135,6 @@ foreign import ccall safe "hs_getnameinfo"
 
 foreign import ccall unsafe "hs_getsockname"
   c_getsockname  :: Fd -> Ptr a -> Ptr CInt -> Ptr CInt -> IO CInt
+
+foreign import ccall unsafe "hs_shutdown"
+  c_shutdown     :: Fd -> CInt -> Ptr CInt -> IO CInt


### PR DESCRIPTION
shutdown is useful since it can be used to send a TCP FIN which in turn
requires the other side to close the connection as well making it
possible to gracefully terminate a TCP connection.

**Windows is untested as of now**, ~~but CI should take care of that~~.

Test cases have been added, unfortunately, the exceptions don't seem to
line up across platforms, but that doesn't seem to be a design goal of
this library.

Currently the action is tied to Stream, rather than TCP (which doesn't
make a difference currently), as the action is not necessarily TCP
specific, but I'm not 100% certain.