### PR TITLE
Fix tests on aarch64-darwin

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -99,6 +99,7 @@ group01 = testGroup "connect" [ testGroup "Inet/Stream/TCP" t1 ]
               case r of
                 Left e   | e == eNetworkUnreachable  -> return ()
                          | e == eAddressNotAvailable -> return ()
+                         | e == eAddressFamilyNotSupported -> return ()
                          | otherwise                 -> throwIO e
                 Right () -> assertFailure "connection should have failed"
           )


### PR DESCRIPTION
Currently, tests are failing on aarch64-darwin:

>         connect to closed port on inetNone:                      FAIL
>          Exception: eAddressFamilyNotSupported
>          HasCallStack backtrace:
>            collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
>            toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
>            throwIO, called at ./Control/Concurrent/Async.hs:110:7 in tasty-1.5.3-D46fKdBDq7pJUpxxQtx5z0:Control.Concurrent.Async